### PR TITLE
Restrict referral code to one per user for easier further referral computation

### DIFF
--- a/be/db.go
+++ b/be/db.go
@@ -70,6 +70,7 @@ func saveReport(r ReportArgs) error {
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
 	result, err := db.Exec(`INSERT
 	  INTO reports (id, team, latitude, longitude, x, y, image)
@@ -85,6 +86,8 @@ func getMap(m ViewPort) ([]MapResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer db.Close()
+
 	log.Printf("%f:%f to %f:%f", m.LatTop, m.LonLeft, m.LatBottom, m.LonRight)
 	//latw := m.LatW / steps
 	//lonw := m.LonW / steps
@@ -125,6 +128,7 @@ func getStats(id string) (StatsResponse, error) {
 	if err != nil {
 		return StatsResponse{}, err
 	}
+	defer db.Close()
 
 	rows, err := db.Query(`
 	   SELECT COUNT(*)
@@ -161,6 +165,7 @@ func getTeams() (TeamsResponse, error) {
 	if err != nil {
 		return TeamsResponse{}, err
 	}
+	defer db.Close()
 
 	rows, err := db.Query(`
 	   SELECT
@@ -280,17 +285,38 @@ func writeReferral(db *sql.DB, key, value string) error {
 	return err
 }
 
-func generateReferral(db *sql.DB, req *GenRefRequest, codeGen func () string) (*GenRefResponse, error) {
+func generateReferral(db *sql.DB, req *GenRefRequest, codeGen func() string) (*GenRefResponse, error) {
 	log.Printf("Generate and store referral code for the user %s", req.Id)
-	refCode := codeGen()
+
+	rows, err := db.Query(`SELECT referral
+		FROM users_refcodes
+		WHERE id = ?`,
+		req.Id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var refCode string
+	// Take only the first row. Ignore others as duplicates are not expected.
+	if rows.Next() {
+		if err := rows.Scan(&refCode); err != nil {
+			return nil, err
+		}
+		return &GenRefResponse{
+			RefValue: refCode,
+		}, nil
+	}
+
+	refCode = codeGen()
 
 	if _, err := db.Exec(`INSERT
 		INTO users_refcodes (id, referral)
 		VALUES (?, ?)`,
 		req.Id, refCode); err != nil {
-			return nil, err
-		}
-	
+		return nil, err
+	}
+
 	return &GenRefResponse{
 		RefValue: refCode,
 	}, nil

--- a/be/privacy.go
+++ b/be/privacy.go
@@ -39,6 +39,7 @@ func UpdatePrivacyAndTOC(c *gin.Context) {
 		log.Printf("%v", err)
 		return
 	}
+	defer db.Close()
 
 	err = updatePrivacyAndTOC(db, &args)
 	if err != nil {

--- a/be/read_report.go
+++ b/be/read_report.go
@@ -43,6 +43,7 @@ func ReadReport(c *gin.Context) {
 		log.Printf("%v", err)
 		return
 	}
+	defer db.Close()
 
 	result, err := readReport(db, args)
 	if err != nil {

--- a/be/referral.go
+++ b/be/referral.go
@@ -44,6 +44,7 @@ func ReadReferral(c *gin.Context) {
 		log.Errorf("%v", err)
 		return
 	}
+	defer db.Close()
 
 	refValue, err := readReferral(db, refQuery.RefKey)
 	if err != nil {
@@ -72,6 +73,7 @@ func WriteReferral(c *gin.Context) {
 		log.Errorf("%v", err)
 		return
 	}
+	defer db.Close()
 
 	if err := writeReferral(db, refData.RefKey, refData.RefValue); err != nil {
 		c.Error(err)
@@ -103,6 +105,7 @@ func GenerateReferral(c *gin.Context) {
 		log.Errorf("%v", err)
 		return
 	}
+	defer db.Close()
 
 	ref, err := generateReferral(db, req, randRefGen)
 	if err != nil {

--- a/be/user.go
+++ b/be/user.go
@@ -49,6 +49,7 @@ func UpdateUser(c *gin.Context) {
 		log.Printf("%v", err)
 		return
 	}
+	defer db.Close()
 
 	err = updateUser(db, &user)
 	if err != nil {

--- a/db/setup.sql
+++ b/db/setup.sql
@@ -50,7 +50,7 @@ SHOW COLUMNS FROM referrals;
 CREATE TABLE IF NOT EXISTS users_refcodes(
   referral CHAR(32) NOT NULL,
   id VARCHAR(255) NOT NULL,
-  PRIMARY KEY (referral)
+  PRIMARY KEY (id)
 );
 SHOW TABLES;
 DESCRIBE TABLE users_refcodes;


### PR DESCRIPTION
1. Restrict referral code to one per user ID
2. Explicit DB connection close