### PR TITLE
Redesigned the deployment process with using docker on cloud and secret manager for passwords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This repository is for CleanApp (http://cleanapp.io) backend development.
 
 # Installation
 
+## Pre-requisites
+
+1.  Make sure that your local machine has Docker installed. https://docs.docker.com/engine/install/
+1.  Make sure you're prepared for working with GoogleCloud.
+    1.  You got necessary access to Google Cloud services. Ask project admins for them.
+    1.  You have gcloud command line interface installed, https://cloud.google.com/sdk/docs/install
+    1.  You are successfully logged in gcloud, https://cloud.google.com/sdk/gcloud/reference/auth/login
+
 ## Build Docker image
 
 1.  Modify the Docker image version if necessary. Open the file `docker/.version` and set the desired value of the `BUILD_VERSION`.
@@ -21,10 +29,10 @@ Pre-requisites: Linux (Debian/Ubuntu/...), this is tested on Google Cloud Ubuntu
    * On GCloud you go to the dashboard, pick the instance, and the click on SSH
 1. Get setup.sh into the current directory, e.g. using
 ```shell
-curl https://raw.githubusercontent.com/cleanappio/cleanapp_back_end_v2/main/setup/setup.sh > setup.sh
+curl https://raw.githubusercontent.com/cleanappio/cleanapp_back_end_v2/main/setup/setup.sh > setup.sh &&
+sudo chmod a+x setup.h
 ```
-3. In case you use non-standard Docker images, open setup.sh and edit two Docker params at the top.
-4. Run
+1. Run
 ```
 ./setup.sh
 ```
@@ -131,11 +139,3 @@ We picked
 ## More
 
 More infro is to be added.
-
-### Draft of an alternative deployment process
-
-**Docker build on gcloud**
-
-```
-gcloud builds submit --region=us-central1 --tag us-central1-docker.pkg.dev/cleanup-mysql-v2/cleanapp-docker-repo/cleanapp-service-image:<tag>
-```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # Cleanapp Backend version 2+
 
 This repository is for CleanApp (http://cleanapp.io) backend development.
-It's a complete rewrite after v.0.
 
-## Installation
+# Installation
 
-Pre-requisites: Linux (Debian/Ubuntu/...), this is tested on Google Drive Ubuntu VPS instance.
+## Build Docker image
+
+1.  Modify the Docker image version if necessary. Open the file `docker/.version` and set the desired value of the `BUILD_VERSION`.
+1.  Run the `docker/build_server_image.sh` from the `docker` directory.
+    ```
+    cd docker &&
+    ./build_server_image.sh
+    ```
+
+## Deploying in Google Cloud
+
+Pre-requisites: Linux (Debian/Ubuntu/...), this is tested on Google Cloud Ubuntu VPS instance.
 
 1. Login to the target machine.
    * On GCloud you go to the dashboard, pick the instance, and the click on SSH
@@ -18,13 +28,8 @@ curl https://raw.githubusercontent.com/cleanappio/cleanapp_back_end_v2/main/setu
 ```
 ./setup.sh
 ```
-5. When doing it, you will be asked to set the DB passwords:
 
-* MYSQL_ROOT_PASSWORD for MySQL root user password.
-* MYSQL_APP_PASSWORD for MySQL password for the API server.
-* MYSQL_READER_PASSWORD for MySQL password for database reading/import.
-
-It should be up and running now. If not, contact eldarm@cleanapp.io
+It should be up and running now.
 
 ## Operations
 
@@ -46,13 +51,6 @@ sudo docker-compose down -v
     3. If you need a different label or prefix, edit ```docker-compose.yaml``` file.
     4. (preferable) Load new images using ```sudo docker pull``` command
     5. Restart services.
-
-## Direct dependencies
-
-Docker images (1.6 is 2.0(Alpha) version):
-1. BE API server: ibnazer/cleanappserver:1.6
-2. BE Database: ibnazer/cleanappdb:1.6
-3. BE application server (currently referral redirection service only): ibnazer/cleanappapp:1.6
 
 ## Open ports
 

--- a/README.md
+++ b/README.md
@@ -134,3 +134,10 @@ We picked
 
 More infro is to be added.
 
+### Draft of an alternative deployment process
+
+**Docker build on gcloud**
+
+```
+gcloud builds submit --region=us-central1 --tag us-central1-docker.pkg.dev/cleanup-mysql-v2/cleanapp-docker-repo/cleanapp-service-image:<tag>
+```

--- a/db/build_db_image.sh
+++ b/db/build_db_image.sh
@@ -1,3 +1,16 @@
 echo "Buiding MySQL DB docker image..."
-docker build . -t ${DOCKER_PREFIX}/cleanappdb:${DOCKER_LABEL}
-# docker push ${DOCKER_PREFIX}/cleanappdb
+
+if [ "$(basename $(pwd))" != "db" ]; then
+  echo "The build image should be run from \"db\" directory."
+  exit 1
+fi
+
+CLOUD_REGION="us-central1"
+PROJECT_NAME="cleanup-mysql-v2"
+DOCKER_IMAGE="cleanapp-docker-repo/cleanapp-db-image"
+DOCKER_TAG="${CLOUD_REGION}-docker.pkg.dev/${PROJECT_NAME}/${DOCKER_IMAGE}"
+
+echo "Building and pushing docker image..."
+gcloud builds submit \
+  --region=${CLOUD_REGION} \
+  --tag ${DOCKER_TAG}:live

--- a/docker/.version
+++ b/docker/.version
@@ -1,0 +1,1 @@
+BUILD_VERSION="2.0.4"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,4 +12,4 @@ COPY ./service .
 # USER cleanapper
 
 EXPOSE 8080/tcp
-CMD "./service" "--mysql_password=${MYSQL_APP_PASSWORD}" "--mysql_host=cleanappdb" # shell form to get env substitution.
+CMD "./service" "--mysql_password=${MYSQL_APP_PASSWORD}" "--mysql_host=cleanapp_db" # shell form to get env substitution.

--- a/docker/build_server_image.sh
+++ b/docker/build_server_image.sh
@@ -1,4 +1,29 @@
 echo "Buiding API server docker image..."
-cp ../bin/service ./
-docker build . -t ${DOCKER_PREFIX}/cleanappserver:${DOCKER_LABEL}
-# docker push ${DOCKER_PREFIX}/cleanappserver
+
+if [ "$(basename $(pwd))" != "docker" ]; then
+  echo "The build image should be run from \"docker\" directory."
+  exit 1
+fi
+
+. .version
+echo "Running docker build for version ${BUILD_VERSION}"
+
+echo "Building binary..."
+test -f service && rm -f service
+
+pushd ../
+GOARCH="amd64" GOOS="linux" go build -o docker/service main/service.go
+popd
+
+CLOUD_REGION="us-central1"
+PROJECT_NAME="cleanup-mysql-v2"
+DOCKER_IMAGE="cleanapp-docker-repo/cleanapp-service-image"
+DOCKER_TAG="${CLOUD_REGION}-docker.pkg.dev/${PROJECT_NAME}/${DOCKER_IMAGE}"
+
+echo "Building and pushing docker image..."
+gcloud builds submit \
+  --region=${CLOUD_REGION} \
+  --tag ${DOCKER_TAG}:${BUILD_VERSION}
+
+echo "Tagging Docker image as live..."
+gcloud artifacts docker tags add ${DOCKER_TAG}:${BUILD_VERSION} ${DOCKER_TAG}:live

--- a/main/client.go
+++ b/main/client.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	serviceUrl  = "http://127.0.0.1:8080" // Local
+	// serviceUrl  = "http://127.0.0.1:8080" // Local
 	// serviceUrl  = "http://34.132.121.53:8080" // Google Cloud
-	// serviceUrl  = "http://api.cleanapp.io:8080" // Google Cloud
+	serviceUrl  = "http://dev.api.cleanapp.io:8080" // Google Cloud
 	contentType = "application/json"
 )
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -15,9 +15,9 @@ cat >up.sh << UP
 
 # Secrets
 cat >.env << ENV
-export MYSQL_ROOT_PASSWORD=\\$(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD")
-export MYSQL_APP_PASSWORD=\\$(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD")
-export MYSQL_READER_PASSWORD=\\$(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD")
+export MYSQL_ROOT_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD"\)
+export MYSQL_APP_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD"\)
+export MYSQL_READER_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD"\)
 
 ENV
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -14,11 +14,16 @@ cat >up.sh << UP
 # Assumes dependencies are in place (docker)
 
 # Secrets
-MYSQL_ROOT_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD")
-MYSQL_APP_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD")
-MYSQL_READER_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD")
+export MYSQL_ROOT_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD")
+export MYSQL_APP_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD")
+export MYSQL_READER_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD")
 
 sudo docker-compose up -d --remove-orphans
+
+export MYSQL_ROOT_PASSWORD=""
+export MYSQL_APP_PASSWORD=""
+export MYSQL_READER_PASSWORD=""
+
 UP
 sudo chmod a+x up.sh
 
@@ -127,9 +132,9 @@ installDocker() {
 installDocker
 
 # Pull images:
-sudo docker pull ${SERVICE_DOCKER_IMAGE}
-sudo docker pull ${DB_DOCKER_IMAGE}
-sudo docker pull ${WEB_DOCKER_IMAGE}
+docker pull ${SERVICE_DOCKER_IMAGE}
+docker pull ${DB_DOCKER_IMAGE}
+docker pull ${WEB_DOCKER_IMAGE}
 
 # Start our docker images.
 ./up.sh

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -14,17 +14,19 @@ cat >up.sh << UP
 # Assumes dependencies are in place (docker)
 
 # Secrets
+cat >.env << ENV
 export MYSQL_ROOT_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD")
 export MYSQL_APP_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD")
 export MYSQL_READER_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD")
 
+ENV
+
 sudo docker-compose up -d --remove-orphans
 
-export MYSQL_ROOT_PASSWORD=""
-export MYSQL_APP_PASSWORD=""
-export MYSQL_READER_PASSWORD=""
+rm -f .env
 
 UP
+
 sudo chmod a+x up.sh
 
 cat >down.sh << DOWN

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -15,9 +15,9 @@ cat >up.sh << UP
 
 # Secrets
 cat >.env << ENV
-export MYSQL_ROOT_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD")
-export MYSQL_APP_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD")
-export MYSQL_READER_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD")
+export MYSQL_ROOT_PASSWORD=\\$(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD")
+export MYSQL_APP_PASSWORD=\\$(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD")
+export MYSQL_READER_PASSWORD=\\$(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD")
 
 ENV
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -15,9 +15,9 @@ cat >up.sh << UP
 
 # Secrets
 cat >.env << ENV
-export MYSQL_ROOT_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD"\)
-export MYSQL_APP_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD"\)
-export MYSQL_READER_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD"\)
+MYSQL_ROOT_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD"\)
+MYSQL_APP_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD"\)
+MYSQL_READER_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD"\)
 
 ENV
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -15,9 +15,9 @@ cat >up.sh << UP
 
 # Secrets
 cat >.env << ENV
-MYSQL_ROOT_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD"\)
-MYSQL_APP_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD"\)
-MYSQL_READER_PASSWORD=\\$\(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD"\)
+MYSQL_ROOT_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD")
+MYSQL_APP_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD")
+MYSQL_READER_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD")
 
 ENV
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -7,28 +7,17 @@
 #
 # Give any arg to skip the installation, e.g. "./setup.sh local"
 
-# Docker stuff:
-DOCKER_LABEL="1.6"       # Docker images label.
-DOCKER_PREFIX="ibnazer"  # Dockerhub images prefix.
-
 # Create necessary files.
-
-cat >.env << ENV
-# Setting secrets, please, edit this file
-# to set the real passwords and then save
-# and exit the editor to let the script contiueß.
-MYSQL_ROOT_PASSWORD=secret
-MYSQL_APP_PASSWORD=secret
-MYSQL_READER_PASSWORD=secret
-# These env variables don't contain any secrets and passed AS IS (no editing)
-REACT_APP_REF_API_ENDPOINT="http://localhost:8080/write_referral/"
-REACT_APP_PLAYSTORE_URL="https://play.google.com/store/apps/details?id=com.cleanapp"
-REACT_APP_APPSTORE_URL="https://apps.apple.com/us/app/cleanapp/id6466403301"
-ENV
 
 cat >up.sh << UP
 # Turn up CleanApp service.
 # Assumes dependencies are in place (docker)
+
+# Secrets
+MYSQL_ROOT_PASSWORD=$(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD")
+MYSQL_APP_PASSWORD=$(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD")
+MYSQL_READER_PASSWORD=$(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD")
+
 sudo docker-compose up -d --remove-orphans
 UP
 sudo chmod a+x up.sh
@@ -41,35 +30,50 @@ sudo docker-compose down
 DOWN
 sudo chmod a+x down.sh
 
+# Docker images
+DOCKER_PREFIX="us-central1-docker.pkg.dev/cleanup-mysql-v2/cleanapp-docker-repo"
+SERVICE_DOCKER_IMAGE="${DOCKER_PREFIX}/cleanapp-service-image:live"
+DB_DOCKER_IMAGE="${DOCKER_PREFIX}/cleanapp-db-image:live"
+WEB_DOCKER_IMAGE="${DOCKER_PREFIX}/cleanapp-web-image:live"
+
+# Cleanapp Web env variables
+REACT_APP_REF_API_ENDPOINT="http://dev.api.cleanapp.io:8080/write_referral/"
+REACT_APP_PLAYSTORE_URL="https://play.google.com/store/apps/details?id=com.cleanapp"
+REACT_APP_APPSTORE_URL="https://apps.apple.com/us/app/cleanapp/id6466403301"
+
 # Create docker-compose.yml file.
 cat >docker-compose.yml << COMPOSE
 version: '3'
 
 services:
-  cleanappserver:
-    container_name: cleanappserver
-    image: ${DOCKER_PREFIX}/cleanappserver:${DOCKER_LABEL}
+  cleanapp_service:
+    container_name: cleanapp_service
+    image: ${SERVICE_DOCKER_IMAGE}
     environment:
-      - MYSQL_ROOT_PASSWORD=\$MYSQL_ROOT_PASSWORD
-      - MYSQL_APP_PASSWORD=\$MYSQL_APP_PASSWORD
+      - MYSQL_ROOT_PASSWORD=\${MYSQL_ROOT_PASSWORD}
+      - MYSQL_APP_PASSWORD=\${MYSQL_APP_PASSWORD}
     ports:
       - 8080:8080
 
-  cleanappdb:
-    container_name: cleanappdb
-    image: ${DOCKER_PREFIX}/cleanappdb:${DOCKER_LABEL}
+  cleanapp_db:
+    container_name: cleanapp_db
+    image: ${DB_DOCKER_IMAGE}
     environment:
-      - MYSQL_ROOT_PASSWORD=\$MYSQL_ROOT_PASSWORD
-      - MYSQL_APP_PASSWORD=\$MYSQL_APP_PASSWORD
-      - MYSQL_READER_PASSWORD=\$MYSQL_READER_PASSWORD
+      - MYSQL_ROOT_PASSWORD=\${MYSQL_ROOT_PASSWORD}
+      - MYSQL_APP_PASSWORD=\${MYSQL_APP_PASSWORD}
+      - MYSQL_READER_PASSWORD=\${MYSQL_READER_PASSWORD}
     volumes:
       - mysql:/var/lib/mysql
     ports:
       - 3306:3306
 
-  cleanappapp:
-    container_name: cleanappapp
-    image: ${DOCKER_PREFIX}/cleanappapp:${DOCKER_LABEL}
+  cleanapp_web:
+    container_name: cleanapp_web
+    image: ${WEB_DOCKER_IMAGE}
+    environment:
+      - REACT_APP_REF_API_ENDPOINT=${REACT_APP_REF_API_ENDPOINT}
+      - REACT_APP_PLAYSTORE_URL=${REACT_APP_PLAYSTORE_URL}
+      - REACT_APP_APPSTORE_URL=${REACT_APP_APPSTORE_URL}
     ports:
       - 3000:3000
 
@@ -77,9 +81,6 @@ volumes:
   mysql:
 
 COMPOSE
-
-# Set passwords. On the target machine you can change 'vim' to your favorite text editor:
-vim .env
 
 # Docker install
 read -p "Do you wish to install this program? [y/N]" yn
@@ -126,14 +127,11 @@ installDocker() {
 installDocker
 
 # Pull images:
-sudo docker pull ${DOCKER_PREFIX}/cleanappserver:${DOCKER_LABEL}
-sudo docker pull ${DOCKER_PREFIX}/cleanappdb:${DOCKER_LABEL}
-sudo docker pull ${DOCKER_PREFIX}/cleanappapp:${DOCKER_LABEL}
+sudo docker pull ${SERVICE_DOCKER_IMAGE}
+sudo docker pull ${DB_DOCKER_IMAGE}
+sudo docker pull ${WEB_DOCKER_IMAGE}
 
 # Start our docker images.
 ./up.sh
-
-# Cleanup passwords from the disk.
-sudo rm .env
 
 echo "*** We are running, done."

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -14,9 +14,9 @@ cat >up.sh << UP
 # Assumes dependencies are in place (docker)
 
 # Secrets
-MYSQL_ROOT_PASSWORD=$(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD")
-MYSQL_APP_PASSWORD=$(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD")
-MYSQL_READER_PASSWORD=$(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD")
+MYSQL_ROOT_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_ROOT_PASSWORD")
+MYSQL_APP_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_APP_PASSWORD")
+MYSQL_READER_PASSWORD=\$(gcloud secrets versions access 1 --secret="MYSQL_READER_PASSWORD")
 
 sudo docker-compose up -d --remove-orphans
 UP


### PR DESCRIPTION
Makes the deployment process more consistent.

1. Uses docker image on Google cloud, no need to have different docker hub accounts, that simplified scripts.
2. Reads secrets from secret manager and writes .env in the up.sh before docker_compose calling, then up.sh removes .env. That allows rerunning down.sh and up.sh w/o running setup.sh. 